### PR TITLE
SVN support

### DIFF
--- a/lib/rake/version_task.rb
+++ b/lib/rake/version_task.rb
@@ -163,7 +163,7 @@ class Rake::VersionTask < Rake::TaskLib
     end
 
     if self.with_svn
-      `svn commit #{self.filename} -m "Version bump to #{version}"`
+      `svn commit #{self.filename} #{self.with_gemspec ? self.gemspec : ''} -m "Version bump to #{version}"`
 
       # This only attempts to make 'standard' tags.  That is, if the
       # current svn URL ends in 'trunk' or 'branches/<branch>', then


### PR DESCRIPTION
I've barely tested this, but I added SVN support.

I'm not sure the tagging stuff should be in there since 'tagging' is merely a convention in SVN (a tag is equivalent to a branch; convention dictates that it be in the tags/ sub directory).
